### PR TITLE
Run the CI on every push

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -2,7 +2,6 @@ name: Test and deploy
 
 on:
   push:
-    branches: [ main, dev ]
   # Allow manual triggering
   workflow_dispatch:
 
@@ -36,7 +35,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7 # Not needed with a .ruby-version file
+          ruby-version: 2.7.4 # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Setup yarn dependencies


### PR DESCRIPTION
As mentioned in Teams, I set the CI to run on every push.

This also fixes the CI to use Ruby 2.7.4 (as detailed here: https://github.com/hpi-swt2-exercise/rails-intro-exercise/commit/f0da9f23afe8051a10b6afd8fd68c2c5690f7e4b).