### PR TITLE
Less restrictive rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,17 +13,6 @@ AllCops:
 # Specific excludes & includes
 #
 
-# Okay to have long examples in feature tests, there are usually many steps
-RSpec/ExampleLength:
-  Exclude:
-    - 'spec/features/*.rb'
-
-# Okay to have more than one expectation in a single block, default: 1
-RSpec/MultipleExpectations:
-  Max: 2
-  Exclude:
-    - 'spec/features/*.rb'
-
 # Ignore LineLength for config files (e.g. with long secret strings)
 Layout/LineLength:
   Exclude:
@@ -93,4 +82,13 @@ Style/SymbolArray:
 
 # Okay to use Rails.root.join('tmp', 'caching-dev.txt')
 Rails/FilePath:
+  Enabled: false
+
+RSpec/InstanceVariable:
+  Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/MultipleExpectations:
   Enabled: false


### PR DESCRIPTION
With these changes, auto-generated scaffold code no longer turns code factor red (Solving it like this is obviously up to debate)