### PR TITLE
Rubocop exlude db migration files from some rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,14 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
     - 'config/**/*'
 
+Metrics/AbcSize:
+  Exclude:
+    - 'db/migrate/*.rb'
+
+Metrics/MethodLength:
+  Exclude:
+    - 'db/migrate/*.rb'
+
 # Configs can complex options, may need custom layout
 Layout/ArgumentAlignment:
   Exclude:


### PR DESCRIPTION
Ignore rules which lead to failure for autogenerated migrations