### PR TITLE
Adds ability to place a marker on the map (Fix #22)

### DIFF
--- a/app/views/map/index.html.erb
+++ b/app/views/map/index.html.erb
@@ -25,8 +25,15 @@
 const key = 'iek_VpPLmIcjE8vIQ7dVhFr3zw3lqTHj';
 
 const view = new ol.View({
-  center: ol.proj.fromLonLat([13.125999496, 52.389498442]),
+  center: ol.proj.fromLonLat([13.133013738895208, 52.39392471456182]),
   zoom: 18,
+});
+
+// the markers are added to this layer
+const markerLayer = new ol.layer.Vector({
+  source: new ol.source.Vector({
+    features: [],
+  }),
 });
 
 const map = new ol.Map({
@@ -34,10 +41,28 @@ const map = new ol.Map({
     new ol.layer.Tile({
       source: new ol.source.OSM(),
     }),
+    markerLayer
   ],
   target: 'map',
   view: view,
 });
+
+// add a marker and log the coordinates
+map.on('click', (event) => {
+    // remove all markers
+    markerLayer.getSource().clear()
+    const marker = new ol.Feature({
+      type: 'icon',
+      geometry: new ol.geom.Circle(event.coordinate, 5),
+    });
+    markerLayer.getSource().addFeature(marker);
+
+    const coordinatesInLonLat = ol.proj.toLonLat(event.coordinate)
+    // TODO: do something with the coordinate
+    console.log(coordinatesInLonLat);
+});
+
+
 const indoorEqual = new IndoorEqual.default(map, { apiKey: key, spriteBaseUrl: 'sprite/indoorequal' });
 const control = new IndoorEqual.LevelControl(indoorEqual);
 map.addControl(control);


### PR DESCRIPTION
Implements ability to click on the map and place a marker at the specified position.
Map coordinates are logged in the console as latitude and longitude.

Placement of markers is also possible with touch input devices (Tested on Android Phone).

Closes Issues #22 