### PR TITLE
Link new person and new locaiton in user edit page

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,3 +1,8 @@
 // Place all the styles related to the Users controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: https://sass-lang.com/
+
+.btn.btn-primary.link-btn {
+    color: white;
+    text-decoration: none;
+}

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -49,6 +49,14 @@
         <%= f.submit "Update User Account", class: 'btn btn-primary' %>
       </div>
     <% end %>
+
+    <h3 class="fw-light mt-5">Contribute Content</h3>
+    
+    <div class="actions mt-3">
+      <%= link_to "Add new person", new_person_path, class: 'btn btn-primary link-btn' %>
+      <%= link_to "Add new location", new_location_path, class: 'btn btn-primary link-btn' %>
+    </div>
+
     <h3 class="fw-light mt-5">Logout Account</h3>
 
      <%= button_to destroy_user_session_path, class: 'btn btn-outline-primary', method: :delete do %>


### PR DESCRIPTION
closes #110 

When clicking on these buttons, you will be forwarded to the correct site.
<img width="247" alt="nav" src="https://user-images.githubusercontent.com/44091658/148546690-6105387c-1938-4ead-8065-271608e3d8b2.PNG">

![image](https://user-images.githubusercontent.com/28907748/148546810-1e851033-0cb8-49ce-80c3-41a7eb7d9330.png)

Can you spot the difference?