### PR TITLE
Feature/rh 130 office hours on person show page

### DIFF
--- a/app/models/openingtime.rb
+++ b/app/models/openingtime.rb
@@ -42,6 +42,10 @@ class Openingtime < ApplicationRecord
     self.class.day_number_to_string_mapping[day]
   end
 
+  def to_string
+    "#{self.day_as_string}, #{self.opens} - #{self.closes}"
+  end
+
   private
 
   def opens_before_closes

--- a/app/models/openingtime.rb
+++ b/app/models/openingtime.rb
@@ -43,7 +43,7 @@ class Openingtime < ApplicationRecord
   end
 
   def to_string
-    "#{self.day_as_string}, #{self.opens} - #{self.closes}"
+    "#{day_as_string}, #{opens} - #{closes}"
   end
 
   private

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -57,7 +57,7 @@
   </div>
 
   <div class="field mb-3 opening-times-container">
-    <%= form.label :openingtimes, class: 'form-label' %>
+    <%= form.label :office_hours, class: 'form-label' %>
     <%= form.fields_for :openingtimes do |o| %>
       <div class="field" id="opening-time-field-<%= o.object.id %>">
         <%= o.select 'day',
@@ -75,7 +75,7 @@
         <% end %>
       </div>
     <% end %>
-    <button class="btn" onclick="event.preventDefault(); addNewOpeningTime(this);" ><i class="fas fa-plus"></i> Add opening time</button>
+    <button class="btn" onclick="event.preventDefault(); addNewOpeningTime(this);" ><i class="fas fa-plus"></i> Add office hour</button>
   </div>
 
   <div class="actions mt-3">

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -1,4 +1,3 @@
-<h1>Here are the Person's details!</h1>
 <p id="notice"><%= notice %></p>
 
 <div class="edit-profile-picture">
@@ -13,7 +12,6 @@
     </div>
   </div>
 </div>
-
 
 <p>
   <strong>First name:</strong>
@@ -44,6 +42,17 @@
           <%= link_to 'Map', building_map_path(target: "#{room.building.location_latitude},#{room.building.location_longitude}")%>
         </li>
       <% end %>
+  </ul>
+</p>
+
+<p>
+  <strong>Office hours:</strong>
+  <ul>
+    <% @person.openingtimes.each do | opening_time | %>
+      <li>
+        <%= opening_time.to_string %>
+      </li>
+    <% end %>
   </ul>
 </p>
 

--- a/spec/features/people/show_person_details_spec.rb
+++ b/spec/features/people/show_person_details_spec.rb
@@ -1,13 +1,40 @@
 require 'rails_helper'
 
 describe "Person Show Page", type: :feature do
-  it "displays a persons' information" do
-    @person_details = FactoryBot.create :person
-    visit person_path(@person_details)
+  before do
+    @person = FactoryBot.create :person
+  end
 
-    expect(page).to have_text @person_details.first_name
-    expect(page).to have_text @person_details.last_name
-    expect(page).to have_text @person_details.email
-    expect(page).to have_text @person_details.phone_number
+  it "displays a persons' information" do
+    visit person_path(@person)
+
+    expect(page).to have_text @person.first_name
+    expect(page).to have_text @person.last_name
+    expect(page).to have_text @person.email
+    expect(page).to have_text @person.phone_number
+  end
+
+  it "displays the rooms where the person can be found" do
+    room1 = create :room
+    room2 = create :room, name: 'C.E.5'
+    @person.rooms = [room1, room2]
+
+    visit person_path(@person)
+
+    expect(page).to have_text room1.name
+    expect(page).to have_link 'Map', :href => building_map_path(target: "#{room1.building.location_latitude},#{room1.building.location_longitude}")
+    expect(page).to have_text room2.name
+    expect(page).to have_link 'Map', :href => building_map_path(target: "#{room2.building.location_latitude},#{room2.building.location_longitude}")
+  end
+
+  it "displays the office hours of the person" do
+    office_hour1 = create :openingtime
+    office_hour2 = create :openingtime, day: 2
+    @person.openingtimes = [office_hour1, office_hour2]
+
+    visit person_path(@person)
+
+    expect(page).to have_text office_hour1.to_string
+    expect(page).to have_text office_hour2.to_string
   end
 end

--- a/spec/features/people/show_person_details_spec.rb
+++ b/spec/features/people/show_person_details_spec.rb
@@ -22,9 +22,11 @@ describe "Person Show Page", type: :feature do
     visit person_path(@person)
 
     expect(page).to have_text room1.name
-    expect(page).to have_link 'Map', :href => building_map_path(target: "#{room1.building.location_latitude},#{room1.building.location_longitude}")
+    expect(page).to have_link 'Map', href:
+      building_map_path(target: "#{room1.building.location_latitude},#{room1.building.location_longitude}")
     expect(page).to have_text room2.name
-    expect(page).to have_link 'Map', :href => building_map_path(target: "#{room2.building.location_latitude},#{room2.building.location_longitude}")
+    expect(page).to have_link 'Map', href:
+      building_map_path(target: "#{room2.building.location_latitude},#{room2.building.location_longitude}")
   end
 
   it "displays the office hours of the person" do


### PR DESCRIPTION
- closes #130 
- Now the configured office hours for a person are also shown on the show page.
- Rename "Openingtimes" on the Person Edit Page to "Office hours" as well.