### PR TITLE
Fix/apmw 212 3 additional import fixes for production

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -52,7 +52,10 @@ $fa-font-path: "@fortawesome/fontawesome-free/webfonts";
 @import "leaflet/dist/leaflet.css";
 //Leaflet layers icon fix
 .leaflet-control-layers-toggle {
-  background-image: asset-url("leaflet/dist/images/layers.png")
+  background-image: asset-url("leaflet/dist/images/layers.png") !important
+}
+.leaflet-retina .leaflet-control-layers-toggle {
+  background-image: asset-url("leaflet/dist/images/layers-2x.png") !important
 }
 
 .app-overlay-bottom {


### PR DESCRIPTION
Addition for #212 to #230 #251 

This fixes the issue for an incorrect path of `background-image` for the layer icon when the css class `leaflet-retina` is present.