### PR TITLE
Allow raw coordinates in routing again

### DIFF
--- a/app/helpers/outdoor_routing_helper.rb
+++ b/app/helpers/outdoor_routing_helper.rb
@@ -17,6 +17,9 @@ module OutdoorRoutingHelper
 
   def self.route_outdoor(start, dest, map_data)
     result = calculate_route(start, dest)
+    # Hint: If you are getting 500ish errors here, it may be because you tried
+    # to test routing from or to the coordinates "0,0", which OSM rejects,
+    # pointing out that you sent a meaningless query - `result` is `nil` then.
     map_data[:polylines].concat([
                                   {
                                     floor: 0,

--- a/app/helpers/routing_helper.rb
+++ b/app/helpers/routing_helper.rb
@@ -115,6 +115,7 @@ module RoutingHelper
   def self.valid_coordinates?(coordinates)
     return false if coordinates.blank?
 
+    # This Regex is shared with `isValidCoordinates` in `building_map.js.erb`
     regex = /^-?\d{1,2}(\.\d+)?,-?\d{1,2}(\.\d+)?$/
     coordinates.match(regex)
   end

--- a/app/javascript/packs/building_map.js.erb
+++ b/app/javascript/packs/building_map.js.erb
@@ -78,8 +78,11 @@ function pinCoordinatesString(pin) {
 }
 
 function validatePlaceInput(inputId, optionsId) {
-  const input = $(`#${inputId}`)[0];
-  const options = $(`#${optionsId}`)[0].options;
+  const input = document.getElementById(inputId);
+  if (isValidCoordinates(input.value)) {
+    return true;
+  }
+  const options = document.getElementById(optionsId).options;
   return Array.from(options).some((o) => o.value === input.value);
 }
 
@@ -89,6 +92,11 @@ function resolveMagicPinStrings(inputField) {
   } else if (inputField.value === PIN_2_MAGIC_STRING) {
     checkPinExistence(1, inputField);
   }
+}
+
+function isValidCoordinates(coordinatesString) {
+  // This Regex is shared with `RoutingHelper.valid_coordinates?`
+  return /^-?\d{1,2}(\.\d+)?,-?\d{1,2}(\.\d+)?$/.test(coordinatesString);
 }
 
 function resolveMagicStrings(inputField) {


### PR DESCRIPTION
Although we don't really have a nice way to start such a navigation by hand, we need it for #262 to work properly. This was never willfully deprecated / removed, the server still has the code to handle such requests
